### PR TITLE
feat: Update training to API NuGet 9.0.0

### DIFF
--- a/PiWeb.Api.Training.OidcAuth/PiWeb.Api.Training.OidcAuth.csproj
+++ b/PiWeb.Api.Training.OidcAuth/PiWeb.Api.Training.OidcAuth.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1293.44" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Zeiss.PiWeb.Api.Rest" Version="8.1.0" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2792.45" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Zeiss.PiWeb.Api.Rest" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/PiWeb.Api.Training/PiWeb.Api.Training.csproj
+++ b/PiWeb.Api.Training/PiWeb.Api.Training.csproj
@@ -1,13 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <UseWPF>true</UseWPF>
-    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Zeiss.PiWeb.Api.Rest" Version="8.1.0" />
+    <PackageReference Include="Zeiss.PiWeb.Api.Rest" Version="9.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Update NuGet dependencies
- remove WPF and Windows since it is not neccessary, only for the OIDC training