### PR TITLE
fix: Correctly handle instance name in events example

### DIFF
--- a/PiWeb.Api.Training.Events/Authentication.cs
+++ b/PiWeb.Api.Training.Events/Authentication.cs
@@ -49,7 +49,7 @@ public static class Authentication
             case AuthenticationMode.Certificate:
                 SetConnectionOptionsForCertificate(options);
                 break;
-            case AuthenticationMode.OpenID:
+            case AuthenticationMode.OpenIDConnect:
                 throw new ArgumentOutOfRangeException(nameof(mode),
                     "Authentication mode is not supported by this client implementation.");
             default:
@@ -94,7 +94,7 @@ public static class Authentication
         try
         {
             using var httpClient = new HttpClient();
-            var jsonResult = await httpClient.GetStringAsync(new Uri(serverUrl, "/.well-known/ServerConfiguration"));
+            var jsonResult = await httpClient.GetStringAsync(new Uri(serverUrl, ".well-known/ServerConfiguration"));
 
             var jsonSerializerOptions = new JsonSerializerOptions();
             jsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
@@ -123,7 +123,7 @@ public static class Authentication
         Basic,
         Windows,
         Certificate,
-        OpenID
+        OpenIDConnect
     }
 
     /// <summary>

--- a/PiWeb.Api.Training.Events/Program.cs
+++ b/PiWeb.Api.Training.Events/Program.cs
@@ -60,6 +60,8 @@ public static class Program
     private static bool TryGetServerUrl([NotNullWhen(true)] out Uri? serverUrl)
     {
         var serverUrlString = ConsoleUI.InputText("Server URL with port");
+        if (!serverUrlString.EndsWith('/'))
+            serverUrlString = $"{serverUrlString}/";
 
         try
         {
@@ -81,7 +83,7 @@ public static class Program
         {
             // Use the SignalR client to connect while specifying the chosen authentication mode
             connection = new HubConnectionBuilder()
-                .WithUrl(new Uri(serverUrl, "/events"), options => Authentication.SetConnectionOptions(authenticationMode, options))
+                .WithUrl(new Uri(serverUrl, "events"), options => Authentication.SetConnectionOptions(authenticationMode, options))
                 .Build();
             return true;
         }


### PR DESCRIPTION
- .NET Uri constructor shortens given Uri to base if no trailing slash is present, which may remove the instance name if copied directly from the PiWeb Server UI
- simply make sure that the user-given Uri ends with a slash before giving it to the constructor
- also adapt enum for OICD authentication to correct value